### PR TITLE
Update Git repo and issue tracker URLs to GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,14 @@ more.
 
 The project maintains the following source code repositories
 
-* https://git.eclipse.org/r/plugins/gitiles/rap/org.eclipse.rap
-* https://git.eclipse.org/r/plugins/gitiles/rap/org.eclipse.rap.tools
+* https://github.com/eclipse-rap/org.eclipse.rap
+* https://github.com/eclipse-rap/org.eclipse.rap.tools
 
-This project uses Bugzilla to track ongoing development and issues.
+This project uses GitHub to track ongoing development and issues.
 
-* Search for issues: https://bugs.eclipse.org/bugs/buglist.cgi?product=RAP
-* Create a new report: https://bugs.eclipse.org/bugs/enter_bug.cgi?product=RAP
+* Search for issues: https://github.com/eclipse-rap/org.eclipse.rap.tools/issues
+* Create a new report: https://github.com/eclipse-rap/org.eclipse.rap.tools/issues/new/choose
+* For old issues until 2022-04, see Bugzilla at https://bugs.eclipse.org/bugs/buglist.cgi?product=RAP
 
 Be sure to search for existing bugs before you create another one. Remember that
 contributions are always welcome!

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -28,8 +28,8 @@ SPDX-License-Identifier: EPL-1.0
 
 The project maintains the following source code repositories:
 
-* https://git.eclipse.org/r/plugins/gitiles/rap/org.eclipse.rap
-* https://git.eclipse.org/r/plugins/gitiles/rap/org.eclipse.rap.tools
+* https://github.com/eclipse-rap/org.eclipse.rap
+* https://github.com/eclipse-rap/org.eclipse.rap.tools
 
 ## Third-party Content
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Contact the project developers via the [RAP Forum] [8] or the project's
 Search for bugs
 ---------------
 
-This project uses Bugzilla to track [ongoing development and issues] [10].
+This project uses GitHub to track [ongoing development and issues] [10].
 
 Create a new bug
 ----------------
@@ -80,5 +80,5 @@ welcome!
 [7]: http://wiki.eclipse.org/EPL
 [8]: http://www.eclipse.org/forums/eclipse.technology.rap
 [9]: https://dev.eclipse.org/mailman/listinfo/rap-dev
-[10]: https://bugs.eclipse.org/bugs/buglist.cgi?product=RAP
-[11]: https://bugs.eclipse.org/bugs/enter_bug.cgi?product=RAP
+[10]: https://github.com/eclipse-rap/org.eclipse.rap/issues
+[11]: https://github.com/eclipse-rap/org.eclipse.rap/issues/new/choose

--- a/releng/org.eclipse.rap.tools.build/pom.xml
+++ b/releng/org.eclipse.rap.tools.build/pom.xml
@@ -24,7 +24,7 @@
     <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
     <tycho-version>2.1.0</tycho-version>
     <signing-plugin-version>1.3.2</signing-plugin-version>
-    <tycho.scmUrl>scm:git:https://git.eclipse.org/r/rap/org.eclipse.rap.tools.git</tycho.scmUrl>
+    <tycho.scmUrl>scm:git:https://github.com/eclipse-rap/org.eclipse.rap.tools</tycho.scmUrl>
     <!-- disabled due to bug 393977
     <baseline-repository>http://download.eclipse.org/rt/rap/nightly/tooling/</baseline-repository>
      -->


### PR DESCRIPTION
* Configure new GitHub repository URL in MANIFEST.MF
* Replace Git and Bugzilla URL references in documentation

Change-Id: Iff9d15c54ba781dbd61f2cb709cf32c002b76deb
Signed-off-by: Markus Knauer <mknauer@eclipsesource.com>