### PR TITLE
Update launch config templates with missing OSGi bundles

### DIFF
--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/basic_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/basic_launch.template
@@ -53,6 +53,11 @@
         <setEntry value="org.eclipse.osgi.services@default:default"/>
         <setEntry value="org.eclipse.osgi.util@default:default"/>
         <setEntry value="org.eclipse.osgi@-1:true"/>
+        <setEntry value="org.osgi.util.function@default:default"/>
+        <setEntry value="org.osgi.util.measurement@default:default"/>
+        <setEntry value="org.osgi.util.position@default:default"/>
+        <setEntry value="org.osgi.util.promise@default:default"/>
+        <setEntry value="org.osgi.util.xml@default:default"/>
         <setEntry value="org.eclipse.rap.rwt.osgi@default:default"/>
         <setEntry value="org.eclipse.rap.rwt@default:default"/>
         <setEntry value="org.slf4j.api@default:default"/>

--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/e4_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/e4_launch.template
@@ -91,6 +91,16 @@
         <setEntry value="org.eclipse.osgi.services@default:default"/>
         <setEntry value="org.eclipse.osgi.util@default:default"/>
         <setEntry value="org.eclipse.osgi@-1:true"/>
+        <setEntry value="org.eclipse.rap.e4@default:default"/>
+        <setEntry value="org.eclipse.rap.jface.databinding@default:default"/>
+        <setEntry value="org.eclipse.rap.jface@default:default"/>
+        <setEntry value="org.eclipse.rap.rwt.osgi@default:default"/>
+        <setEntry value="org.eclipse.rap.rwt@default:default"/>
+        <setEntry value="org.osgi.util.function@default:default"/>
+        <setEntry value="org.osgi.util.measurement@default:default"/>
+        <setEntry value="org.osgi.util.position@default:default"/>
+        <setEntry value="org.osgi.util.promise@default:default"/>
+        <setEntry value="org.osgi.util.xml@default:default"/>
         <setEntry value="org.slf4j.api@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">

--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/workbench_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/workbench_launch.template
@@ -69,6 +69,11 @@
         <setEntry value="org.eclipse.osgi.services@default:default"/>
         <setEntry value="org.eclipse.osgi.util@default:default"/>
         <setEntry value="org.eclipse.osgi@-1:true"/>
+        <setEntry value="org.osgi.util.function@default:default"/>
+        <setEntry value="org.osgi.util.measurement@default:default"/>
+        <setEntry value="org.osgi.util.position@default:default"/>
+        <setEntry value="org.osgi.util.promise@default:default"/>
+        <setEntry value="org.osgi.util.xml@default:default"/>
         <setEntry value="org.eclipse.rap.design.example@default:default"/>
         <setEntry value="org.eclipse.rap.jface.databinding@default:default"/>
         <setEntry value="org.eclipse.rap.jface@default:default"/>


### PR DESCRIPTION
Now org.osgi.util.* bundles are needed for normal operation.