### PR TITLE
Use port 8080 as new default in launch configurations

### DIFF
--- a/bundles/org.eclipse.rap.tools.launch/src/org/eclipse/rap/tools/launch/internal/RAPLaunchConfig.java
+++ b/bundles/org.eclipse.rap.tools.launch/src/org/eclipse/rap/tools/launch/internal/RAPLaunchConfig.java
@@ -45,7 +45,7 @@ public final class RAPLaunchConfig {
   // Default values for launch configuration attribute names
   private static final String DEFAULT_SERVLET_PATH = "/rap"; //$NON-NLS-1$
   private static final BrowserMode DEFAULT_BROWSER_MODE = BrowserMode.INTERNAL;
-  private static final int DEFAULT_PORT = 10080;
+  private static final int DEFAULT_PORT = 8080;
   private static final boolean DEFAULT_USE_MANUAL_PORT = false;
   private static final String DEFAULT_CONTEXTPATH = "/";
   private static final boolean DEFAULT_USE_MANUAL_CONTEXTPATH = false;

--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/basic_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/basic_launch.template
@@ -25,7 +25,7 @@
     <stringAttribute key="org.eclipse.rap.launch.dataLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.rap.tools.launch/${projectName}"/>
     <booleanAttribute key="org.eclipse.rap.launch.developmentMode" value="true"/>
     <booleanAttribute key="org.eclipse.rap.launch.openBrowser" value="true"/>
-    <intAttribute key="org.eclipse.rap.launch.port" value="10080"/>
+    <intAttribute key="org.eclipse.rap.launch.port" value="8080"/>
     <stringAttribute key="org.eclipse.rap.launch.servletPath" value="${servletPath}"/>
     <intAttribute key="org.eclipse.rap.launch.sessionTimeout" value="0"/>
     <booleanAttribute key="org.eclipse.rap.launch.terminatePrevious" value="true"/>

--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/e4_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/e4_launch.template
@@ -25,7 +25,7 @@
     <stringAttribute key="org.eclipse.rap.launch.dataLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.rap.tools.launch/${projectName}"/>
     <booleanAttribute key="org.eclipse.rap.launch.developmentMode" value="true"/>
     <booleanAttribute key="org.eclipse.rap.launch.openBrowser" value="true"/>
-    <intAttribute key="org.eclipse.rap.launch.port" value="10080"/>
+    <intAttribute key="org.eclipse.rap.launch.port" value="8080"/>
     <stringAttribute key="org.eclipse.rap.launch.servletPath" value="${servletPath}"/>
     <intAttribute key="org.eclipse.rap.launch.sessionTimeout" value="0"/>
     <booleanAttribute key="org.eclipse.rap.launch.terminatePrevious" value="true"/>

--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/workbench_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/workbench_launch.template
@@ -25,7 +25,7 @@
     <stringAttribute key="org.eclipse.rap.launch.dataLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.rap.tools.launch/${projectName}"/>
     <booleanAttribute key="org.eclipse.rap.launch.developmentMode" value="true"/>
     <booleanAttribute key="org.eclipse.rap.launch.openBrowser" value="true"/>
-    <intAttribute key="org.eclipse.rap.launch.port" value="10080"/>
+    <intAttribute key="org.eclipse.rap.launch.port" value="8080"/>
     <stringAttribute key="org.eclipse.rap.launch.servletPath" value="${servletPath}"/>
     <intAttribute key="org.eclipse.rap.launch.sessionTimeout" value="0"/>
     <booleanAttribute key="org.eclipse.rap.launch.terminatePrevious" value="true"/>


### PR DESCRIPTION
To protect users from the [NAT Slipstreaming attack](https://samy.pl/slipstream/),
[Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1689107) and
[Chrome](https://chromestatus.com/feature/6510270304223232) started to
block any access to port 10080 which used to be the default port in new
RAP launch configurations.

Use the alternative port for HTTP (8080) in the launch configuration and
all launch templates.

Fixes #9