### PR TITLE
Synchronise SLF4J plugin to Eclipse Platform

### DIFF
--- a/bundles/org.eclipse.rap.tools.launch.rwt/src/org/eclipse/rap/tools/launch/rwt/internal/delegate/RWTLaunchDelegate.java
+++ b/bundles/org.eclipse.rap.tools.launch.rwt/src/org/eclipse/rap/tools/launch/rwt/internal/delegate/RWTLaunchDelegate.java
@@ -81,7 +81,7 @@ public class RWTLaunchDelegate extends JavaLaunchDelegate {
     list.add( BundleFileLocator.locate( "org.eclipse.jetty.util.ajax" ) ); //$NON-NLS-1$
     list.add( BundleFileLocator.locate( "org.eclipse.jetty.webapp" ) ); //$NON-NLS-1$
     list.add( BundleFileLocator.locate( "org.eclipse.jetty.xml" ) ); //$NON-NLS-1$
-    list.add( BundleFileLocator.locate( "org.slf4j.api" ) ); //$NON-NLS-1$
+    list.add( BundleFileLocator.locate( "slf4j.api" ) ); //$NON-NLS-1$
     return list.toArray( new String[0] );
   }
 

--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/basic_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/basic_launch.template
@@ -70,7 +70,7 @@
         <setEntry value="org.osgi.util.position"/>
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
-        <setEntry value="org.slf4j.api"/>
+        <setEntry value="slf4j.api"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="${pluginId}@default:default"/>

--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/e4_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/e4_launch.template
@@ -111,7 +111,7 @@
         <setEntry value="org.osgi.util.position"/>
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
-        <setEntry value="org.slf4j.api"/>
+        <setEntry value="slf4j.api"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="${pluginId}@default:default"/>

--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/workbench_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/workbench_launch.template
@@ -92,7 +92,7 @@
         <setEntry value="org.osgi.util.position"/>
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
-        <setEntry value="org.slf4j.api"/>
+        <setEntry value="slf4j.api"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="${pluginId}@default:default"/>

--- a/features/org.eclipse.rap.tools.feature/feature.xml
+++ b/features/org.eclipse.rap.tools.feature/feature.xml
@@ -162,7 +162,7 @@
          unpack="false"/>
 
    <plugin
-         id="org.slf4j.api"
+         id="slf4j.api"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/tests/org.eclipse.rap.tools.launch.rwt.test/src/org/eclipse/rap/tools/launch/rwt/internal/delegate/RWTLaunchDelegate_Test.java
+++ b/tests/org.eclipse.rap.tools.launch.rwt.test/src/org/eclipse/rap/tools/launch/rwt/internal/delegate/RWTLaunchDelegate_Test.java
@@ -121,7 +121,6 @@ public class RWTLaunchDelegate_Test {
       "org.eclipse.jetty.util.ajax",
       "org.eclipse.jetty.webapp",
       "org.eclipse.jetty.xml",
-      "org.slf4j.api",
     };
     for( String bundle : bundles ) {
       boolean found = false;


### PR DESCRIPTION
Use the same slf4j.api bundle as Eclipse Platform that retrieves it from Maven Central instead of the older outdated one from Eclipse Orbit.

Please note that this changes the bundle symbolic name from org.slf4j.api to the shorter slf4j.api which requires to adjust all launch templates.

This pull request is addressing the same topic as eclipse-rap/org.eclipse.rap/pull/80 in RAP Runtime.