### PR TITLE
Add "slf4j.nop" bundle to all template launch configurations

### DIFF
--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/basic_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/basic_launch.template
@@ -71,6 +71,7 @@
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
         <setEntry value="slf4j.api"/>
+        <setEntry value="slf4j.nop"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="${pluginId}@default:default"/>

--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/e4_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/e4_launch.template
@@ -112,6 +112,7 @@
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
         <setEntry value="slf4j.api"/>
+        <setEntry value="slf4j.nop"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="${pluginId}@default:default"/>

--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/workbench_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/workbench_launch.template
@@ -93,6 +93,7 @@
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
         <setEntry value="slf4j.api"/>
+        <setEntry value="slf4j.nop"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="${pluginId}@default:default"/>


### PR DESCRIPTION
SLF4J implementation is required for successful execution.