### PR TITLE
Create additional self-contained p2 repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <module>features/org.eclipse.rap.tools.feature</module>
     <!-- The p2 repository -->
     <module>releng/org.eclipse.rap.tools.build/repository</module>
+    <module>releng/org.eclipse.rap.tools.build/repository-selfcontained</module>
   </modules>
 
 </project>

--- a/releng/org.eclipse.rap.tools.build/repository-selfcontained/category.xml
+++ b/releng/org.eclipse.rap.tools.build/repository-selfcontained/category.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2011, 2023 EclipseSource and others
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+
+  Contributors:
+     EclipseSource - initial implementation
+-->
+<site>
+   <feature url="http://eclipse.org/rap" id="org.eclipse.rap.tools.feature" version="3.26.0.qualifier">
+      <category name="org.eclipse.rap.category"/>
+   </feature>
+   <category-def name="org.eclipse.rap.category" label="Remote Application Platform (RAP) - self contained"/>
+</site>

--- a/releng/org.eclipse.rap.tools.build/repository-selfcontained/pom.xml
+++ b/releng/org.eclipse.rap.tools.build/repository-selfcontained/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2011, 2023 EclipseSource and others
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+
+  Contributors:
+     EclipseSource - initial implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.rap</groupId>
+    <artifactId>org.eclipse.rap.tools-parent</artifactId>
+    <version>3.26.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.eclipse.rap.tools-repository-selfcontained</artifactId>
+  <packaging>eclipse-repository</packaging>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <resolver>p2</resolver>
+          <environments>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>macosx</os>
+              <ws>cocoa</ws>
+              <arch>x86_64</arch>
+            </environment>
+          </environments>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-repository-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <repositoryName>RAP Tools</repositoryName>
+          <includeAllDependencies>true</includeAllDependencies>
+          <compress>true</compress>
+          <finalName>rap-tools-selfcontained-${unqualifiedVersion}-${buildType}-${build}</finalName>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
This additional p2 repository is created during build time for each build and can be used to develop RAP Tools in the IDE with the very same target bundles like they are used in the regular build.