### PR TITLE
Update SECURITY.md following template changes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,49 +1,21 @@
-<!--- https://www.eclipse.org/security/ --->
-_ISO 27005 defines vulnerability as:
- "A weakness of an asset or group of assets that can be exploited by one or more threats."_
+<!--
+    For any questions about implementing security best practices, contact the
+    Eclipse Foundation Security Team at security@eclipse-foundation.org
+-->
 
-## The Eclipse Security Team
+# How To Report a Vulnerability
 
-The Eclipse Security Team provides help and advice to Eclipse projects
-on vulnerability issues and is the first point of contact
-for handling security vulnerabilities.
-Members of the Security Team are committers on Eclipse Projects
-and members of the Eclipse Architecture Council.
+If you think you have found a vulnerability in Eclipse RAP you can report it using one of the following ways:
 
-Contact the [Eclipse Security Team](mailto:security@eclipse.org).
+* Contact the [Eclipse Foundation Security Team](mailto:security@eclipse-foundation.org)
+* Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability)
 
-**Note that, as a matter of policy, the security team does not open attachments.**
+You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
 
-## Reporting a Security Vulnerability
+# Supported Versions
 
-Vulnerabilities can be reported either via email to the Eclipse Security Team
-or directly with a project via the Eclipse Foundation's Bugzilla instance.
+The project team is small, and as a result, it can only provide free support for the latest released version. Since Eclipse RAP versions are generally backward compatible, the project team advises users to always use the latest release. Commercial support is available for older versions.
 
-The general security mailing list address is security@eclipse.org.
-Members of the Eclipse Security Team will receive messages sent to this address.
-This address should be used only for reporting undisclosed vulnerabilities;
-regular issue reports and questions unrelated to vulnerabilities in Eclipse software
-will be ignored.
-Note that this email address is not encrypted.
+# Security Policy
 
-The community is also encouraged to report vulnerabilities using the
-[Eclipse Foundation's Bugzilla instance](https://bugs.eclipse.org/bugs/enter_bug.cgi?product=Community&component=Vulnerability%20Reports&keywords=security&groups=Security_Advisories).
-Note that you will require an Eclipse Foundation account to create an issue report,
-but by doing so you will be able to participate directly in the resolution of the issue.
-
-Issue reports related to vulnerabilities must be marked as "committers-only",
-either automatically by clicking the provided link, by the reporter,
-or by a committer during the triage process.
-Note that issues marked "committers-only" are visible to all Eclipse committers.
-By default, a "committers-only" issue is also accessible to the reporter
-and individuals explicitly indicated in the "cc" list.
-
-## Disclosure
-
-Disclosure is initially limited to the reporter and all Eclipse Committers,
-but is expanded to include other individuals, and the general public.
-The timing and manner of disclosure is governed by the
-[Eclipse Security Policy](https://www.eclipse.org/security/policy.php).
-
-Publicly disclosed issues are listed on the
-[Disclosed Vulnerabilities Page](https://www.eclipse.org/security/known.php).
+This project follows [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy/).


### PR DESCRIPTION
Incorporate the changes in `SECURITY.md` from the Eclipse Foundation template at

https://gitlab.eclipse.org/security/best-practices/-/blob/main/templates/SECURITY.md