### PR TITLE
Prepare for JavaSE 21

### DIFF
--- a/bundles/org.eclipse.rap.doc/pom.xml
+++ b/bundles/org.eclipse.rap.doc/pom.xml
@@ -71,7 +71,7 @@
               <url>${eclipserun-repo}</url>
             </repository>
           </repositories>
-          <executionEnvironment>JavaSE-17</executionEnvironment>
+          <executionEnvironment>JavaSE-21</executionEnvironment>
         </configuration>
         <executions>
           <execution>

--- a/bundles/org.eclipse.rap.tools.intro/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.tools.intro/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui.intro,
  org.eclipse.equinox.p2.metadata,
  org.eclipse.equinox.p2.core,
  org.eclipse.equinox.p2.repository
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.rap.tools.intro/build.properties
+++ b/bundles/org.eclipse.rap.tools.intro/build.properties
@@ -22,4 +22,4 @@ src.includes = cheatsheets/,\
                intro/,\
                about.html
 javacDefaultEncoding.. = UTF-8
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.rap.tools.launch.rwt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.tools.launch.rwt/META-INF/MANIFEST.MF
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.jetty.util.ajax;bundle-version="[12.0.0,13.0.0)",
  org.eclipse.jetty.xml;bundle-version="[12.0.0,13.0.0)"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-Vendor: %Bundle-Vendor
 Export-Package: org.eclipse.rap.tools.launch.rwt.internal;x-internal:=true,

--- a/bundles/org.eclipse.rap.tools.launch.rwt/build.properties
+++ b/bundles/org.eclipse.rap.tools.launch.rwt/build.properties
@@ -21,4 +21,4 @@ bin.includes = META-INF/,\
 src.includes = about.html,\
                icons/
 javacDefaultEncoding.. = UTF-8
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.rap.tools.launch/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.tools.launch/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.rap.tools.launch.internal;x-friends:="org.eclipse.rap.tools.tests",
  org.eclipse.rap.tools.launch.internal.tab;x-friends:="org.eclipse.rap.tools.tests",
  org.eclipse.rap.tools.launch.internal.util;x-friends:="org.eclipse.rap.tools.tests"

--- a/bundles/org.eclipse.rap.tools.launch/build.properties
+++ b/bundles/org.eclipse.rap.tools.launch/build.properties
@@ -20,4 +20,4 @@ bin.includes = META-INF/,\
 src.includes = icons/,\
                about.html
 javacDefaultEncoding.. = UTF-8
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.rap.tools.templates/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.tools.templates/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 4.2.0.qualifier
 Bundle-Vendor: %bundleProvider
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.rap.tools.templates.internal.Activator
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/releng/org.eclipse.rap.tools.build/pom.xml
+++ b/releng/org.eclipse.rap.tools.build/pom.xml
@@ -22,7 +22,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
-    <tycho-version>3.0.4</tycho-version>
+    <tycho-version>4.0.10</tycho-version>
     <signing-plugin-version>1.3.2</signing-plugin-version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-rap/org.eclipse.rap.tools</tycho.scmUrl>
     <!-- disabled due to bug 393977

--- a/tests/org.eclipse.rap.tools.launch.rwt.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.tools.launch.rwt.test/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: org.eclipse.rap.tools.launch.rwt.test
 Bundle-Version: 4.2.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: org.eclipse.rap.tools.launch.rwt;bundle-version="[4.2.0,5.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.junit;bundle-version="4.8.2"
 Automatic-Module-Name: org.eclipse.rap.tools.launch.rwt.test

--- a/tests/org.eclipse.rap.tools.launch.rwt.test/build.properties
+++ b/tests/org.eclipse.rap.tools.launch.rwt.test/build.properties
@@ -16,4 +16,4 @@ bin.includes = META-INF/,\
                about.html
 src.includes = about.html
 javacDefaultEncoding.. = UTF-8
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/tests/org.eclipse.rap.tools.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.tools.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.rap.tools.tests
 Bundle-Version: 4.2.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",

--- a/tests/org.eclipse.rap.tools.tests/build.properties
+++ b/tests/org.eclipse.rap.tools.tests/build.properties
@@ -16,5 +16,5 @@ bin.includes = META-INF/,\
                plugin.properties,\
                about.html
 javacDefaultEncoding.. = UTF-8
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21
 src.includes = about.html


### PR DESCRIPTION
- Upgrade to latest Tycho 4.x version because the older 3.x version does not support the required Java level.
- Change the projects and bundles, and update MANIFEST.MF to require the higher execution environment, and the build.properties to use the higher level compiler.