### PR TITLE
Update e4 launch config template

### DIFF
--- a/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/e4_launch.template
+++ b/bundles/org.eclipse.rap.tools.templates/src/org/eclipse/rap/tools/templates/internal/rap/e4_launch.template
@@ -42,8 +42,7 @@
         <setEntry value="org.apache.aries.spifly.dynamic.bundle"/>
         <setEntry value="org.apache.commons.collections"/>
         <setEntry value="org.apache.commons.commons-beanutils"/>
-        <setEntry value="org.apache.commons.jxpath"/>
-        <setEntry value="org.apache.commons.logging"/>
+        <setEntry value="org.apache.commons.commons-logging"/>
         <setEntry value="org.apache.felix.gogo.command"/>
         <setEntry value="org.apache.felix.gogo.runtime"/>
         <setEntry value="org.apache.felix.gogo.shell"/>


### PR DESCRIPTION
- use "org.apache.commons.commons-logging"
- remove "org.apache.commons.jxpath", which is not used with Jakarta EE10