### PR TITLE
Upgrade to Tycho 4.0.13, remove deprecated configuration

### DIFF
--- a/bundles/org.eclipse.rap.doc/pom.xml
+++ b/bundles/org.eclipse.rap.doc/pom.xml
@@ -33,8 +33,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho.extras</groupId>
-        <artifactId>tycho-eclipserun-plugin</artifactId>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-eclipse-plugin</artifactId>
         <version>${tycho-version}</version>
         <configuration>
           <applicationArgs>

--- a/releng/org.eclipse.rap.tools.build/pom.xml
+++ b/releng/org.eclipse.rap.tools.build/pom.xml
@@ -22,8 +22,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
-    <tycho-version>4.0.10</tycho-version>
-    <signing-plugin-version>1.3.2</signing-plugin-version>
+    <tycho-version>4.0.13</tycho-version>
+    <signing-plugin-version>1.5.2</signing-plugin-version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-rap/org.eclipse.rap.tools</tycho.scmUrl>
     <!-- disabled due to bug 393977
     <baseline-repository>http://download.eclipse.org/rt/rap/nightly/tooling/</baseline-repository>

--- a/releng/org.eclipse.rap.tools.build/repository-selfcontained/pom.xml
+++ b/releng/org.eclipse.rap.tools.build/repository-selfcontained/pom.xml
@@ -32,7 +32,6 @@
         <artifactId>target-platform-configuration</artifactId>
         <version>${tycho-version}</version>
         <configuration>
-          <resolver>p2</resolver>
           <environments>
             <environment>
               <os>linux</os>


### PR DESCRIPTION
- Bumped Tycho version from 4.0.10 to 4.0.13, signing-plugin version to 1.5.2
- Relocated tycho-eclipserun-plugin to tycho-eclipse-plugin
- Removed deprecated resolver parameter from target-platform-configuration